### PR TITLE
Latin1 ”åäö” detect

### DIFF
--- a/Codesets.c
+++ b/Codesets.c
@@ -35,7 +35,7 @@
 #define INFO "Simple UTF-8 support using codesets.library"
 #define SETUPNAME "Codesets"
 
-/* #define DEBUG */
+//#define DEBUG 
 
 /***************************************************************************/
 
@@ -84,7 +84,7 @@ int strlen( const char *a )
 
 char *strcpy( char *a, const char *b )
 {
-    while( ( *a++ = *b++ ) );
+    while( ( *a++ = *b++ )  );
     return(--a);
 }
 
@@ -103,7 +103,12 @@ int findiso( const char *a)
 {
     ULONG pos = 0;
     ULONG len=strlen(a);
-    while( pos < len && *a) { if (*a==0xe5||*a==0xe4||*a==0xf6||*a==0xc5||*a==0xc4||*a==0xd5) return 1;a++;pos++; };
+    while( pos < len && *a) { 
+	    if (*a==0xe5||*a==0xe4||*a==0xf6||*a==0xc5||*a==0xc4||*a==0xd5) 
+		    return 1;
+	    a++;
+	    pos++; 
+    }
     return 0; /* no match */
 }
 
@@ -168,6 +173,7 @@ int AMIPLUG_Hook_Rawline( REG(a0,struct amiplug_functable *ctx), REG(a1,STRPTR l
     }
 if (findiso((const char*)line))
 	return 0;
+        
     dst = CodesetsConvertStr (CSA_SourceCodeset, (ULONG)data->serverCodeset,
                                 CSA_DestCodeset, (ULONG)data->amigaCodeset,
                                 CSA_Source, (ULONG)line,

--- a/Codesets.c
+++ b/Codesets.c
@@ -99,11 +99,11 @@ int strnicmp( const char *a, const char *b, ULONG len )
 
 
 
-int findiso( const char *a, const char b)
+int findiso( const char *a)
 {
     ULONG pos = 0;
     ULONG len=strlen(a);
-    while( pos < len && *a) { if (*a==b) return 1;a++;pos++; };
+    while( pos < len && *a) { if (*a==0xe5||*a==0xe4||*a==0xf6||*a==0xc5||*a==0xc4||*a==0xd5) return 1;a++;pos++; };
     return 0; /* no match */
 }
 
@@ -166,8 +166,7 @@ int AMIPLUG_Hook_Rawline( REG(a0,struct amiplug_functable *ctx), REG(a1,STRPTR l
         ctx->amiplug_out_defwin( ctx, amirc_tc_local, (STRPTR)"\eb«Error»", (STRPTR)"Codesets: Invalid codeset to client or server." );
         return 0;
     }
-
-if (findiso((const char*)line,0xe5)||findiso((const char*)line,0xe4)||findiso((const char*)line,0xf6)||findiso((const char*)line,0xc5)||findiso((const char*)line,0xc4)||findiso((const char*)line,0xd5))
+if (findiso((const char*)line))
 	return 0;
     dst = CodesetsConvertStr (CSA_SourceCodeset, (ULONG)data->serverCodeset,
                                 CSA_DestCodeset, (ULONG)data->amigaCodeset,

--- a/Codesets.c
+++ b/Codesets.c
@@ -97,6 +97,18 @@ int strnicmp( const char *a, const char *b, ULONG len )
     return 1; /* no match */
 }
 
+
+
+int findiso( const char *a, const char b)
+{
+    ULONG pos = 0;
+    ULONG len=strlen(a);
+    while( pos < len && *a) { if (*a==b) return 1;a++;pos++; };
+    return 0; /* no match */
+}
+
+
+
 /***************************************************************************/
 
 struct amiplug_cmd mycmd = {{NULL,NULL},"UTF8","[ON/OFF]", 1, 0, FALSE};
@@ -155,6 +167,8 @@ int AMIPLUG_Hook_Rawline( REG(a0,struct amiplug_functable *ctx), REG(a1,STRPTR l
         return 0;
     }
 
+if (findiso((const char*)line,0xe5)||findiso((const char*)line,0xe4)||findiso((const char*)line,0xf6)||findiso((const char*)line,0xc5)||findiso((const char*)line,0xc4)||findiso((const char*)line,0xd5))
+	return 0;
     dst = CodesetsConvertStr (CSA_SourceCodeset, (ULONG)data->serverCodeset,
                                 CSA_DestCodeset, (ULONG)data->amigaCodeset,
                                 CSA_Source, (ULONG)line,
@@ -244,7 +258,6 @@ char *AMIPLUG_Hook_Input( REG(a0,struct amiplug_functable *ctx), REG(a1,STRPTR s
         ctx->amiplug_out_defwin( ctx, amirc_tc_local, (STRPTR)"\eb«Error»", (STRPTR)"Codesets: Invalid codeset to client or server." );
         return (char *)string;
     }
-
 #ifdef DEBUG
     PutStr("Input:'"); PutStr(string); PutStr("'\n");
 #endif


### PR DESCRIPTION
There is a problem when chating in Swedish. If the other end sends latin1 the characters ”åäöÅÄÖ”  becomes ’?’. My solution is to scan the strings for those characters and skip translation if found.

Feel free to change it to your liking!